### PR TITLE
en_us - "Cut pickle" to "Cut Pickle"

### DIFF
--- a/src/main/resources/assets/culturaldelights/lang/en_us.json
+++ b/src/main/resources/assets/culturaldelights/lang/en_us.json
@@ -9,7 +9,7 @@
   "item.culturaldelights.cucumber": "Cucumber",
   "item.culturaldelights.pickle": "Pickle",
   "item.culturaldelights.cut_cucumber": "Cut Cucumber",
-  "item.culturaldelights.cut_pickle": "Cut pickle",
+  "item.culturaldelights.cut_pickle": "Cut Pickle",
   "item.culturaldelights.white_eggplant": "White Eggplant",
   "item.culturaldelights.eggplant": "Eggplant",
   "item.culturaldelights.smoked_eggplant": "Smoked Eggplant",


### PR DESCRIPTION
Capitalization fix in English item name