### PR TITLE
Fixes #6 : Add Registry entries for missing items/blocks + fix condition type in loot_tables.

### DIFF
--- a/src/main/java/com/ncpbails/culturaldelights/block/ModBlocks.java
+++ b/src/main/java/com/ncpbails/culturaldelights/block/ModBlocks.java
@@ -83,6 +83,12 @@ public class ModBlocks {
                 @Override public int getFireSpreadSpeed(BlockState state, BlockGetter world, BlockPos pos, Direction face) { return 30; }
             }, false, 0);
 
+    public static final RegistryObject<Block> AVOCADO_LEAF_CARPET = registerBlock("avocado_leaf_carpet",
+            () -> new Block(BlockBehaviour.Properties.copy(Blocks.CYAN_CARPET)) {
+                @Override public boolean isFlammable(BlockState state, BlockGetter world, BlockPos pos, Direction face) { return true; }
+                @Override public int getFlammability(BlockState state, BlockGetter world, BlockPos pos, Direction face) { return 60; }
+                @Override public int getFireSpreadSpeed(BlockState state, BlockGetter world, BlockPos pos, Direction face) { return 30; }
+            }, true, 300);
 
     public static final RegistryObject<Block> CUCUMBERS = registerBlockWithoutBlockItem("cucumbers",
             () -> new CucumbersBlock(BlockBehaviour.Properties.copy(Blocks.WHEAT).noOcclusion()));
@@ -98,6 +104,10 @@ public class ModBlocks {
 
 
     public static final RegistryObject<Block> AVOCADO_CRATE = registerBlock("avocado_crate",
+            () -> new Block(BlockBehaviour.Properties.copy(vectorwing.farmersdelight.common.registry.ModBlocks.CARROT_CRATE.get()))
+            , false, 0);
+
+    public static final RegistryObject<Block> AVOCADO_BUNDLE = registerBlock("avocado_bundle",
             () -> new Block(BlockBehaviour.Properties.copy(vectorwing.farmersdelight.common.registry.ModBlocks.CARROT_CRATE.get()))
             , false, 0);
 
@@ -122,6 +132,9 @@ public class ModBlocks {
             , false, 0);
 
     public static final RegistryObject<Block> EXOTIC_ROLL_MEDLEY = registerBlock("exotic_roll_medley",
+            () -> new ExoticRollMedleyBlock(BlockBehaviour.Properties.copy(vectorwing.farmersdelight.common.registry.ModBlocks.RICE_ROLL_MEDLEY_BLOCK.get()).noOcclusion()), false, 0);
+
+    public static final RegistryObject<Block> EXOTIC_ROLL_MEDLEY_BLOCK = registerBlock("exotic_roll_medley_block",
             () -> new ExoticRollMedleyBlock(BlockBehaviour.Properties.copy(vectorwing.farmersdelight.common.registry.ModBlocks.RICE_ROLL_MEDLEY_BLOCK.get()).noOcclusion()), false, 0);
 
 

--- a/src/main/resources/data/culturaldelights/loot_tables/blocks/avocado_leaves.json
+++ b/src/main/resources/data/culturaldelights/loot_tables/blocks/avocado_leaves.json
@@ -12,7 +12,7 @@
               "type": "minecraft:item",
               "conditions": [
                 {
-                  "condition": "minecraft:alternative",
+                  "condition": "minecraft:any_of",
                   "terms": [
                     {
                       "condition": "minecraft:match_tool",
@@ -103,7 +103,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
@@ -160,7 +160,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",

--- a/src/main/resources/data/culturaldelights/loot_tables/blocks/fruiting_avocado_leaves.json
+++ b/src/main/resources/data/culturaldelights/loot_tables/blocks/fruiting_avocado_leaves.json
@@ -12,7 +12,7 @@
               "type": "minecraft:item",
               "conditions": [
                 {
-                  "condition": "minecraft:alternative",
+                  "condition": "minecraft:any_of",
                   "terms": [
                     {
                       "condition": "minecraft:match_tool",
@@ -103,7 +103,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
@@ -160,7 +160,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",


### PR DESCRIPTION
Fixes #6 :
- Add missing Blocks/items Registry entries. Please review them. I've put placeholder atributes as I do not know the intent behind thoses objectes.
- Fix "Condition Type" in loot_tables : minecraft:alternative has been replaced by minecraft:any_of